### PR TITLE
Fix argument list being matched on bitwise OR operator

### DIFF
--- a/syntaxes/wren.json
+++ b/syntaxes/wren.json
@@ -36,7 +36,7 @@
                 { "include": "#code" },
                 {
                     "name": "meta.block.parameters.wren",
-                    "begin": "\\|",
+                    "begin": "(?<=\\{\\s*)\\|",
                     "end": "\\|",
                     "patterns": [
                         {


### PR DESCRIPTION
Any `|` operator inside any block was matched as a beginning of a function parameter list, which made the rest of the file completely lose highlighting, until another `|` was matched to end it. With this change the parameter list is matched only at the beginning of a block.

Example code before:
![pic-selected-2021-05-03_13:53:07](https://user-images.githubusercontent.com/19764975/116873490-11a2b300-ac18-11eb-89ff-804272351ba1.png)
And after:
![pic-selected-2021-05-03_13:53:27](https://user-images.githubusercontent.com/19764975/116873509-18312a80-ac18-11eb-92ad-38e5f29970cd.png)
