### PR TITLE
Wren 0.4.0 and some fixes

### DIFF
--- a/syntaxes/wren.json
+++ b/syntaxes/wren.json
@@ -36,7 +36,7 @@
                 { "include": "#code" },
                 {
                     "name": "meta.block.parameters.wren",
-                    "begin": "\\|",
+                    "begin": "(?<=\\{\\s*)\\|",
                     "end": "\\|",
                     "patterns": [
                         {

--- a/syntaxes/wren.json
+++ b/syntaxes/wren.json
@@ -4,8 +4,7 @@
     "fileTypes": [ "wren" ],
 
     "patterns": [
-        { "include": "#code" },
-        { "include": "#class" }
+        { "include": "#code" }
     ],
     "repository": {
         "comment": {
@@ -51,7 +50,7 @@
             "patterns": [
                 {
                     "name": "keyword.control.wren",
-                    "match": "\\b(?:break|else|for|if|import|in|return|while|var)\\b"
+                    "match": "\\b(?:as|break|continue|else|for|if|import|in|return|while|var)\\b"
                 },
                 {
                     "name": "keyword.operator.wren",
@@ -87,7 +86,7 @@
                 },
                 {
                     "name": "constant.numeric.wren",
-                    "match": "\\b(0x[0-9a-fA-F]*|[0-9]+(\\.?[0-9]*)?(e(\\+|-)?[0-9]+)?)\\b"
+                    "match": "\\b(0x[0-9a-fA-F]*|[0-9]+(\\.?[0-9]*)?([eE](\\+|-)?[0-9]+)?)\\b"
                 },
                 {
                     "name": "constant.numeric.hexadecimal.wren",
@@ -123,7 +122,7 @@
             "patterns": [
                 {
                     "name": "constant.character.escape.wren",
-                    "match": "\\\\(?:[0\"\\abfnrtv]|x[0-9A-Fa-f]{2}|u[0-9A-Fa-f]{4}|U[0-9A-Fa-f]{4})"
+                    "match": "\\\\(?:[0\"\\abefnrtv]|x[0-9A-Fa-f]{2}|u[0-9A-Fa-f]{4}|U[0-9A-Fa-f]{4})"
                 },
                 {
                     "name": "invalid.illegal.unknown-escape.wren",
@@ -134,6 +133,11 @@
                     "match": "%\\((.*?)\\)"
                 }
             ]
+        },
+        "multilineString": {
+            "name": "string.quoted.multi.wren",
+            "begin": "\"\"\"",
+            "end": "\"\"\""
         },
         "function": {
             "name": "meta.function.wren",
@@ -160,6 +164,8 @@
         },
         "code": {
             "patterns": [
+                { "include": "#attribute" },
+                { "include": "#class" },
                 { "include": "#blockComment" },
                 { "include": "#comment" },
                 { "include": "#block" },
@@ -167,10 +173,19 @@
                 { "include": "#constant" },
                 { "include": "#variable" },
                 { "include": "#string" },
+                { "include": "#multilineString" },
                 { "include": "#function" },
                 { "include": "#static_function" },
                 { "include": "#static_constant" }
             ]
+        },
+        "attribute": {
+            "name": "meta.attribute.wren",
+            "match": "^\\s*(#\\s*!?)\\s*(\\w+)",
+            "captures": {
+                "1": { "name": "punctuation.attribute.wren" },
+                "2": { "name": "entity.name.attribute.wren" }
+            }
         },
         "method": {
             "name": "meta.method.wren",
@@ -289,6 +304,7 @@
                         "0": { "name": "punctuation.section.class.begin.wren" }
                     },
                     "patterns": [
+                        { "include": "#attribute" },
                         { "include": "#comment" },
                         { "include": "#blockComment" },
                         { "include": "#foreignMethod" },


### PR DESCRIPTION
This PR updates the grammar to support features added in Wren 0.4.0 and it fixes a couple of other minor details:
- add `as` and `continue`
- add the `\e` string escape
- add raw (multiline) strings
- add attributes
- allow capital `E` inside floating point literals
- allow classes in non-top-level code
- fix block argument list being matched on any `|` inside a block.