### PR TITLE
Fixed syntax highlighting for binary or '|'

### DIFF
--- a/syntaxes/wren.json
+++ b/syntaxes/wren.json
@@ -36,7 +36,7 @@
                 { "include": "#code" },
                 {
                     "name": "meta.block.parameters.wren",
-                    "begin": "\\|",
+                    "begin": "(?<=\\{)\\s*\\|",
                     "end": "\\|",
                     "patterns": [
                         {
@@ -60,6 +60,10 @@
                 {
                     "name": "keyword.operator.logical.wren",
                     "match": "!|&&|\\|\\|"
+                },
+                {
+                    "name": "keyword.operator.bitwise.wren",
+                    "match": "&|\\||\\^|<<|>>"
                 },
                 {
                     "name": "keyword.operator.range.wren",


### PR DESCRIPTION
The syntax highlighter treated any single | character in the code as the start of a closure parameter list, so it was breaking the highlighting until it found a closing |. I have a codebase with bitwise ORs and this fixed highlighting for it.